### PR TITLE
fix #3 allow empty commits

### DIFF
--- a/buildAndReleaseTask/publish.ps1
+++ b/buildAndReleaseTask/publish.ps1
@@ -36,7 +36,7 @@ try {
     git config user.email $githubemail
     git config user.name $githubusername
     git add *
-    git commit -m $commitMessage
+    git commit --allow-empty -m $commitMessage
 
     if ($lastexitcode -gt 0)
     {


### PR DESCRIPTION
@JamesRandall This is a simple solution I thought should fix #3. The `--allow-empty` parameter allows empty commits so the task should succeed