### PR TITLE
push quiet

### DIFF
--- a/buildAndReleaseTask/publish.ps1
+++ b/buildAndReleaseTask/publish.ps1
@@ -44,7 +44,7 @@ try {
         [Environment]::Exit(1)
     }
 
-    git push
+    git push --quiet
 
     if ($lastexitcode -gt 0)
     {


### PR DESCRIPTION
Powershell seems to interpret output as an error.  Setting quiet solves the issue.