### PR TITLE
Add the ability to also specify other branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A build and release task to update GitHub Pages as part of a VSTS build or relea
 
 To use the plugin you need to:
 
-1. Have configured GitHub Pages to be hosted within the a gh-pages(or other specified) branch of your repository. Setup instructions can be found [here](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/).
+1. Have configured GitHub Pages to be hosted within the gh-pages(or other specified) branch of your repository. Setup instructions can be found [here](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/).
 2. Obtain a Personal Access Token that the build task can use to commit to your gh-pages(or other specified) branch. Instructions for doing that can be found [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/). 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A build and release task to update GitHub Pages as part of a VSTS build or relea
 
 To use the plugin you need to:
 
-1. Have configured GitHub Pages to be hosted within the gh-pages branch of your repository. Setup instructions can be found [here](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/).
-2. Obtain a Personal Access Token that the build task can use to commit to your gh-pages branch. Instructions for doing that can be found [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/). 
+1. Have configured GitHub Pages to be hosted within the a gh-pages(or other specified) branch of your repository. Setup instructions can be found [here](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/).
+2. Obtain a Personal Access Token that the build task can use to commit to your gh-pages(or other specified) branch. Instructions for doing that can be found [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/). 
 
 ## Installation
 

--- a/buildAndReleaseTask/publish.ps1
+++ b/buildAndReleaseTask/publish.ps1
@@ -10,12 +10,13 @@ try {
     $githubaccesstoken = Get-VstsInput -Name 'githubaccesstoken' -Require
     $repositoryname = Get-VstsInput -Name 'repositoryname' -Require
     $commitMessage = Get-VstsInput -Name 'commitmessage' -Require
+    $branchName = Get-VstsInput -Name 'branchname' -Require
 
     $defaultWorkingDirectory = Get-VstsTaskVariable -Name 'System.DefaultWorkingDirectory'    
     
-    Write-Host "Cloning existing GitHub Pages branch"
+    Write-Host "Cloning existing GitHub repository"
 
-    git clone https://${githubusername}:$githubaccesstoken@github.com/$githubusername/$repositoryname.git --branch=gh-pages $defaultWorkingDirectory\ghpages --quiet
+    git clone https://${githubusername}:$githubaccesstoken@github.com/$githubusername/$repositoryname.git --branch=$branchName $defaultWorkingDirectory\ghpages --quiet
     
     if ($lastexitcode -gt 0)
     {
@@ -29,7 +30,7 @@ try {
 
     Copy-Item $docPath $to -recurse -Force
 
-    Write-Host "Committing the GitHub Pages Branch"
+    Write-Host "Committing the GitHub repository"
 
     cd $defaultWorkingDirectory\ghpages
     git config core.autocrlf false
@@ -48,7 +49,7 @@ try {
 
     if ($lastexitcode -gt 0)
     {
-        Write-Host "##vso[task.logissue type=error;]Error pushing to gh-pages branch, probably an incorrect Personal Access Token, error code $lastexitcode"
+        Write-Host "##vso[task.logissue type=error;]Error pushing to $branchName branch, probably an incorrect Personal Access Token, error code $lastexitcode"
         [Environment]::Exit(1)
     }
 

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -1,8 +1,8 @@
 {
-    "id": "65386086-C58C-4396-BC83-4C7A39E84448",
-    "name": "GitHubPagesPublish",
+    "id": "65386086-C58C-4396-BC83-4C7A39E84348",
+    "name": "GitHubPagesPublishBrancher",
     "friendlyName": "Publish to GitHub Pages",
-    "description": "Publishes files to a GitHub Pages gh-pages branch",
+    "description": "Publishes files to a GitHub repository",
     "helpMarkDown": "",
     "category": "Utility",
     "visibility": [
@@ -12,7 +12,7 @@
     "author": "James Randall",
     "version": {
         "Major": 0,
-        "Minor": 13,
+        "Minor": 14,
         "Patch": 0
     },
     "instanceNameFormat": "Publishes to GitHub Pages",
@@ -62,7 +62,15 @@
             "label": "Repository Name",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Your GitHub repository name. It must have a gh-pages branch."
+            "helpMarkDown": "Your GitHub repository name."
+        },
+        {
+            "name": "branchname",
+            "type": "string",
+            "label": "Branch Name",
+            "defaultValue": "gh-pages",
+            "required": true,
+            "helpMarkDown": "Your GitHub repository branch."
         },
         {
             "name": "commitmessage",

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -1,6 +1,6 @@
 {
     "id": "65386086-C58C-4396-BC83-4C7A39E84448",
-    "name": "GitHubPagesPublishBrancher",
+    "name": "GitHubPagesPublish",
     "friendlyName": "Publish to GitHub Pages",
     "description": "Publishes files to a GitHub repository",
     "helpMarkDown": "",

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "65386086-C58C-4396-BC83-4C7A39E84348",
+    "id": "65386086-C58C-4396-BC83-4C7A39E84448",
     "name": "GitHubPagesPublishBrancher",
     "friendlyName": "Publish to GitHub Pages",
     "description": "Publishes files to a GitHub repository",


### PR DESCRIPTION
For me the `gh-pages` branch is not an option. I don't want the complexity of having another branch. I'd rather have a  master branch with a `docs` folder from where i host my website.

This pr adds the ability to specify a branch so that you can host it in any branch you like. Also requested by issue #7 

Tested it by creating and publishing this version of the extension, already unlisted it.