### PR TITLE
Added option to clean the repository before copying the source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ You'll then need to set the required parameters for the publishing process:
 |Commit Message|The message you want associated with the commit - this defaults to "Automated Release $(Release.ReleaseId)"|
 |Clean Repository?|Check this parameter to clean the repository before copying the source files.|
 
+## YAML Example
+
+Here's an example of how to use the task in a YAML pipeline:
+
+```YAML
+- task: GitHubPagesPublish@1
+  inputs:
+    docPath: '$(System.DefaultWorkingDirectory)\Documentation\site\*'
+    githubusername: 'user'
+    githubemail: 'user@example.org'
+    githubaccesstoken: '*****'
+    repositoryname: 'your-repository'
+    branchname: 'gh-pages'
+    commitmessage: 'Automated Release $(Release.ReleaseId)'
+    cleanRepository: false
+```
+
 ## Bits and Pieces
 
 It's really just a wrapper over some Git commands which you can see in the PowerShell script if you want to take a look or use this as a baseline for something slightly different.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ You'll then need to set the required parameters for the publishing process:
 |GitHub Personal Access Token|The personal access token you obtained earlier. I recommend storing this in a secure VSTS build and release variable.|
 |GitHub Email Address|The email address you want associated with the commit to the gh-pages branch|
 |Repository Name|The name of the GitHub repository that you want to publish pages to|
-|Commit Message|The message you want associated with the commit - this defaults to "Automated Release $(Release.ReleaseId)"
+|Commit Message|The message you want associated with the commit - this defaults to "Automated Release $(Release.ReleaseId)"|
+|Clean Repository?|Check this parameter to clean the repository before copying the source files.|
 
 ## Bits and Pieces
 

--- a/buildAndReleaseTask/publish.ps1
+++ b/buildAndReleaseTask/publish.ps1
@@ -33,7 +33,7 @@ try {
     if ($cleanRepository)
     {
         Write-Host "Cleaning the GitHub repository"
-        git rm -r '*'
+        git rm -f -r '*'
     }
 
     $to = "$defaultWorkingDirectory\ghpages"

--- a/buildAndReleaseTask/publish.ps1
+++ b/buildAndReleaseTask/publish.ps1
@@ -11,6 +11,7 @@ try {
     $repositoryname = Get-VstsInput -Name 'repositoryname' -Require
     $commitMessage = Get-VstsInput -Name 'commitmessage' -Require
     $branchName = Get-VstsInput -Name 'branchname' -Require
+    $cleanRepository = Get-VstsInput -Name 'cleanrepository' -AsBool -Require
 
     $defaultWorkingDirectory = Get-VstsTaskVariable -Name 'System.DefaultWorkingDirectory'    
     
@@ -24,6 +25,17 @@ try {
         [Environment]::Exit(1)
     }
     
+    cd $defaultWorkingDirectory\ghpages
+    git config core.autocrlf false
+    git config user.email $githubemail
+    git config user.name $githubusername
+
+    if ($cleanRepository)
+    {
+        Write-Host "Cleaning the GitHub repository"
+        git rm -r '*'
+    }
+
     $to = "$defaultWorkingDirectory\ghpages"
 
     Write-Host "Copying new documentation into branch"
@@ -32,10 +44,6 @@ try {
 
     Write-Host "Committing the GitHub repository"
 
-    cd $defaultWorkingDirectory\ghpages
-    git config core.autocrlf false
-    git config user.email $githubemail
-    git config user.name $githubusername
     git add *
     git commit --allow-empty -m $commitMessage
 

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -84,7 +84,7 @@
             "name": "cleanRepository",
             "type": "boolean",
             "label": "Clean Repository?",
-            "defaultValue": "false",
+            "defaultValue": false,
             "required": true,
             "helpMarkDown": "Check this setting to clean the repository before copying the source files."
         }

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -79,6 +79,14 @@
             "defaultValue": "Automated Release $(Release.ReleaseId)",
             "required": true,
             "helpMarkDown": "The message that is attached to the commit"
+        },
+        {
+            "name": "cleanRepository",
+            "type": "boolean",
+            "label": "Clean Repository?",
+            "defaultValue": "false",
+            "required": true,
+            "helpMarkDown": "Check this setting to clean the repository before copying the source files."
         }
     ],
     "execution": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "githubpages-publish",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": "GitHub Pages Publish",
     "public": true,
     "description": "Publishes documentation to GitHub Pages",


### PR DESCRIPTION
I've added the option to clean the repository before the source files are copied. It can be turned on and off by a new parameter on the task. It's set to false by default so it won't impact existing pipelines when they update.

I tried publishing a private version of the extensions to test it but couldn't create a publisher in the market place because I didn't have enough rights. I'll have to look in to that.

I have tested the script itself though and it works for me.