### PR TITLE
Add github url to support github enterprise, default to github.com

### DIFF
--- a/buildAndReleaseTask/publish.ps1
+++ b/buildAndReleaseTask/publish.ps1
@@ -11,12 +11,13 @@ try {
     $repositoryname = Get-VstsInput -Name 'repositoryname' -Require
     $commitMessage = Get-VstsInput -Name 'commitmessage' -Require
     $branchName = Get-VstsInput -Name 'branchname' -Require
+    $githubUrl = Get-VstsInput -Name 'githuburl' -Require
 
     $defaultWorkingDirectory = Get-VstsTaskVariable -Name 'System.DefaultWorkingDirectory'    
     
     Write-Host "Cloning existing GitHub repository"
 
-    git clone https://${githubusername}:$githubaccesstoken@github.com/$githubusername/$repositoryname.git --branch=$branchName $defaultWorkingDirectory\ghpages --quiet
+    git clone https://${githubusername}:$githubaccesstoken@$githubUrl/$githubusername/$repositoryname.git --branch=$branchName $defaultWorkingDirectory\ghpages --quiet
     
     if ($lastexitcode -gt 0)
     {

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -5,14 +5,11 @@
     "description": "Publishes files to a GitHub repository",
     "helpMarkDown": "",
     "category": "Utility",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "James Randall",
     "version": {
         "Major": 1,
-        "Minor": 0,
+        "Minor": 1,
         "Patch": 0
     },
     "instanceNameFormat": "Publishes to GitHub Pages",
@@ -31,6 +28,14 @@
             "defaultValue": "$(System.DefaultWorkingDirectory)\\Documentation\\site\\*",
             "required": true,
             "helpMarkDown": "Source files"
+        },
+        {
+            "name": "githuburl",
+            "type": "string",
+            "label": "GitHub/GitHub Enterprise URL",
+            "defaultValue": "github.com",
+            "required": true,
+            "helpMarkDown": "GitHub or GitHub Enterprise URL"
         },
         {
             "name": "githubusername",
@@ -84,9 +89,7 @@
     "execution": {
         "PowerShell3": {
             "target": "publish.ps1",
-            "platforms": [
-                "windows"
-            ],
+            "platforms": ["windows"],
             "workingDirectory": "$(currentDirectory)"
         }
     }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,23 +1,21 @@
 {
     "manifestVersion": 1,
     "id": "githubpages-publish",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": "GitHub Pages Publish",
     "public": true,
     "description": "Publishes documentation to GitHub Pages",
-    "categories": [
-        "Build and release"
-    ],
+    "categories": ["Build and release"],
     "publisher": "AccidentalFish",
     "targets": [
         {
             "id": "Microsoft.VisualStudio.Services"
-            }
-        ],
+        }
+    ],
     "icons": {
         "default": "icon.png"
-     },
-     "content": {
+    },
+    "content": {
         "details": {
             "path": "README.md"
         },
@@ -46,9 +44,7 @@
         {
             "id": "AccidentalFish.GitHubPages-Publish",
             "type": "ms.vss-distributed-task.task",
-            "targets": [
-                "ms.vss-distributed-task.tasks"
-            ],
+            "targets": ["ms.vss-distributed-task.tasks"],
             "properties": {
                 "name": "buildAndReleaseTask"
             }


### PR DESCRIPTION
To use this extension in Azure DevOps Server (on-prem version of DevOps) with an on-prem instance of github enterprise the code needed to accept the github url.  This PR includes those changes with a default set to github.com as the code was originally coded.